### PR TITLE
Fix typo in 03-preprocessing.ipynb

### DIFF
--- a/01-ml-workflow/03-preprocessing.ipynb
+++ b/01-ml-workflow/03-preprocessing.ipynb
@@ -536,7 +536,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Looking at distances in the original space, Shopper 0 is most similar to Shopper 2, as the counts are most similar. However, it might make more sense to have Shopper 0 be more similar to Shopper 2, as the both mostly show for fashion.\n",
+    "Looking at distances in the original space, Shopper 0 is most similar to Shopper 2, as the counts are most similar. However, it might make more sense to have Shopper 0 be more similar to Shopper 1, as the both mostly show for fashion.\n",
     "the Normalizer accomplishes that by normalizing by the total number of visits (when using the l1 distance):"
    ]
   },


### PR DESCRIPTION
Currently reads "However, it might make more sense to have Shopper 0 be more similar to Shopper 2" but should read "However, it might make more sense to have Shopper 0 be more similar to Shopper 1".